### PR TITLE
Fix Cancel typo in modal buttons

### DIFF
--- a/src/_root/pages/GroupDetails.tsx
+++ b/src/_root/pages/GroupDetails.tsx
@@ -273,7 +273,7 @@ const GroupDetails = () => {
               If deleted, the Group expense will be permanently removed.
             </p>
             <Button className="btn bg-red hover:bg-red" onClick={toggleModal2}>
-              Cancle
+              Cancel
             </Button>
             <Button className="btn m-2 bg-green-400" onClick={handleDelete}>
               Confirm

--- a/src/components/shared/UserCard.tsx
+++ b/src/components/shared/UserCard.tsx
@@ -182,7 +182,7 @@ const UserCard: React.FC<UserCardProps> = ({
               repayment between two user
             </p>
             <Button className="btn bg-red hover:bg-red" onClick={toggleModal}>
-              Cancle
+              Cancel
             </Button>
             <Button className="btn m-2 bg-green-400" onClick={toggleModal}>
               Confirm


### PR DESCRIPTION
## Summary
- fix 'Cancle' typo in UserCard and GroupDetails components

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_685195cbe990832baa1ae113d2b0607b